### PR TITLE
updating to use lyo relese 2.2.0

### DIFF
--- a/lyo-rest-workshop/Lab1/pom.xml
+++ b/lyo-rest-workshop/Lab1/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab1</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -20,24 +44,30 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>javax.servlet.jsp-api</artifactId>
+			<version>2.2.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -49,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
@@ -74,12 +104,6 @@
 			<groupId>jstl</groupId>
 			<artifactId>jstl</artifactId>
 			<version>1.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet.jsp</groupId>
-			<artifactId>javax.servlet.jsp-api</artifactId>
-			<version>2.2.1</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
   

--- a/lyo-rest-workshop/Lab2/pom.xml
+++ b/lyo-rest-workshop/Lab2/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab2</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -20,24 +44,30 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>javax.servlet.jsp</groupId>
+			<artifactId>javax.servlet.jsp-api</artifactId>
+			<version>2.2.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -49,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
@@ -74,12 +104,6 @@
 			<groupId>jstl</groupId>
 			<artifactId>jstl</artifactId>
 			<version>1.1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.servlet.jsp</groupId>
-			<artifactId>javax.servlet.jsp-api</artifactId>
-			<version>2.2.1</version>
-			<scope>provided</scope>
 		</dependency>
 	</dependencies>
   

--- a/lyo-rest-workshop/Lab3/pom.xml
+++ b/lyo-rest-workshop/Lab3/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab3</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -28,22 +52,22 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -55,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>

--- a/lyo-rest-workshop/Lab4/pom.xml
+++ b/lyo-rest-workshop/Lab4/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab4</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -28,22 +52,22 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -55,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>

--- a/lyo-rest-workshop/Lab5/pom.xml
+++ b/lyo-rest-workshop/Lab5/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab5</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -28,22 +52,22 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -55,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>

--- a/lyo-rest-workshop/Lab6/pom.xml
+++ b/lyo-rest-workshop/Lab6/pom.xml
@@ -5,7 +5,31 @@
   <artifactId>oslc4j-bugzilla-sample-lab6</artifactId>
   <packaging>war</packaging>
   <version>0.0.1-SNAPSHOT</version>
-
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+      <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
+      <version.lyo>2.2.0</version.lyo>
+  </properties>
+  <repositories>
+      <repository>
+          <id>lyo-releases</id>
+          <name>Eclipse Lyo Releases</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+          <snapshots>
+              <enabled>false</enabled>
+          </snapshots>
+      </repository>
+      <repository>
+          <id>lyo-snapshots</id>
+          <name>Eclipse Lyo Snapshots</name>
+          <url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+          <releases>
+              <enabled>false</enabled>
+          </releases>
+      </repository>
+  </repositories>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -28,22 +52,22 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-core</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-wink</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-json4j-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 			<artifactId>oslc4j-jena-provider</artifactId>
-			<version>[0.1.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.j2bugzilla</groupId>
@@ -55,20 +79,20 @@
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-webapp</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 			<type>war</type>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-core</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.eclipse.lyo.server</groupId>
 			<artifactId>oauth-consumer-store</artifactId>
-			<version>[0.0.1-SNAPSHOT,)</version>
+			<version>${version.lyo}</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
2.2.0 is the latest version of Lyo, with which I could easily build and run the adaptors with.
I tried 2.3.0 and that caused some errors. I am sure we can make it work, but will do that in future fixes.